### PR TITLE
Remove "Imprint" artifact

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
 				<ul>
 					<li style="border: none;">> <a href="profile.html">Profile</a></li>
 					<li style="border: none;">> <a href="mailto:lambda@azet.org">Contact</a></li>
-					<li style="border: none;">> <a href="imprint.html">Imprint</a></li>
+					<li style="border: none;">> <a href="legal.html">Legal Disclosure</a></li>
 					<li style="border: none;">> <a href="https://github.com/lambda-co-at">GitHub</a></li>
 				</ul>
 			</nav>

--- a/legal.html
+++ b/legal.html
@@ -11,7 +11,7 @@
                 <ul>
                         <li><a href="profile.html">Profile</a></li>
                         <li><a href="mailto:lambda@azet.org">Contact</a></li>
-                        <li><a href="imprint.html">Imprint</a></li>
+                        <li><a href="legal.html">Legal Disclosure</a></li>
                         <li><a href="https://github.com/lambda-co-at">GitHub</a></li>
                 </ul>
         </nav>

--- a/profile.html
+++ b/profile.html
@@ -11,7 +11,7 @@
                 <ul>
                         <li><a href="profile.html">Profile</a></li>
                         <li><a href="mailto:lambda@azet.org">Contact</a></li>
-                        <li><a href="imprint.html">Imprint</a></li>
+                        <li><a href="legal.html">Legal Disclosure</a></li>
                         <li><a href="https://github.com/lambda-co-at">GitHub</a></li>
                 </ul>
         </nav>


### PR DESCRIPTION
See
- https://en.wikipedia.org/wiki/Impressum
- http://www.language-boutique.com/lost-in-translation-full-reader/impressum-or-imprint.html

Sorry, I visited your web page and my general inconvenience with the dirty translation of "Impressum" made me submit this PR. I know many pages use the word "Imprint", however that does not make it any better in my opinion.
